### PR TITLE
Moved placement of searching for available gpu devices to prevent break on cpu only

### DIFF
--- a/voltools/utils/general.py
+++ b/voltools/utils/general.py
@@ -75,15 +75,15 @@ def get_available_devices():
 
     available_devices = ['cpu']
 
-    # get all available gpus
-    gpu_ids = GPUtil.getAvailable()
-
     # check if cupy is installed
     try:
         import cupy
 
         # add auto gpu
         available_devices.append('gpu')
+
+        # get all available gpus
+        gpu_ids = GPUtil.getAvailable()
 
         # add gpus to list of available devices
         for i in gpu_ids:


### PR DESCRIPTION
Hi Ilja, made a tiny update to the available device check. I was importing voltools on a computer without any gpu's and the check of GPUtil.getAvailable() fails then. This prevents import of voltools. Would you be able to merge it?