### PR TITLE
center calculation done on non-existing object in static volume

### DIFF
--- a/voltools/volume.py
+++ b/voltools/volume.py
@@ -99,7 +99,7 @@ class StaticVolume:
                   profile: bool = False, output = None) -> Union[np.ndarray, None]:
 
         if center is None:
-            center = np.divide(np.subtract(volume.shape, 1), 2, dtype=np.float32)
+            center = np.divide(np.subtract(self.shape, 1), 2, dtype=np.float32)
 
         # passing just one float is uniform scaling
         if isinstance(scale, float):


### PR DESCRIPTION
Hey, noticed a bug in StaticVolume transforms where the center is calculated from a volume parameter that is not passed to the function. It should calculate the center from self.shape (or self.data.shape)!