### PR TITLE
removed GPUtil usage and switched to cupy device count due to GPUtil inconsistency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 numpy
 scipy
-gputil

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,7 @@ setuptools.setup(
     platforms=['any'],
     install_requires=[
         'numpy',
-        'scipy',
-        'gputil'
+        'scipy'
     ],
     packages=setuptools.find_packages(),
     include_package_data=True,

--- a/voltools/utils/general.py
+++ b/voltools/utils/general.py
@@ -1,6 +1,5 @@
 import numpy as np
 from typing import Tuple
-import GPUtil
 try:
     import cupy
 except ImportError:
@@ -70,11 +69,8 @@ def get_available_devices():
         # add auto gpu
         available_devices.append('gpu')
 
-        # get all available gpus
-        gpu_ids = GPUtil.getAvailable()
-
-        # add gpus to list of available devices
-        for i in gpu_ids:
+        # make list of possible devices
+        for i in range(cupy.cuda.runtime.getDeviceCount()):
             available_devices.append(f'gpu:{i}')
 
     except ImportError:


### PR DESCRIPTION
Hi, another PR of a small issue. I noticed that GPUtil sometimes randomly does not find the available device (see below my ipython output). That is problematic because voltools then sometimes does crashes when trying to run the code on a specific device with the following error:

```
  File "/home/marten/coding/pytom-template-matching-gpu/src/pytom_tm/structures.py", line 50, in __init__
    self.mask_texture = vt.StaticVolume(self.mask, interpolation='filt_bspline', device=f'gpu:{device_id}')
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/marten/miniconda3/envs/pytom_tm/lib/python3.11/site-packages/voltools/volume.py", line 21, in __init__
    raise ValueError(f'Unknown device ({device}), must be one of {get_available_devices()}')
ValueError: Unknown device (gpu:0), must be one of ['cpu', 'gpu']
```

This PR has a potential fix by switching to cupy.cuda.runtime.getDeviceCount(). However, I do not know how good this fix is as the cupy docs on this function are [very bare](https://docs.cupy.dev/en/stable/reference/generated/cupy.cuda.runtime.getDeviceCount.html#). Before merging this it would be good to get your input on a solution!

```
In [85]: GPUtil.getAvailable(includeNan=True)
Out[85]: [0]

In [86]: GPUtil.getAvailable(includeNan=True)
Out[86]: [0]

In [87]: GPUtil.getAvailable(includeNan=True)
Out[87]: []

In [88]: GPUtil.getAvailable(includeNan=True)
Out[88]: [0]
```